### PR TITLE
Enable jekyll-feed plugin for RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,3 +39,8 @@ paginate: 3
 
 # Exclude metadata and development time dependencies (like Grunt plugins)
 exclude: [README.markdown, package.json, grunt.js, Gruntfile.js, Gruntfile.coffee, node_modules]
+
+# Plugins
+plugins:
+  - jekyll-feed
+  - jekyll-paginate


### PR DESCRIPTION
Add plugins section to _config.yml with jekyll-feed and jekyll-paginate. The RSS feed will be available at /feed.xml.